### PR TITLE
feat: 案件管理API実装（CRUD）

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,5 +1,131 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from typing import Optional
+from uuid import UUID
+
+from app.core.database import get_db
+from app.api.auth import get_current_user
+from app.models.user import User
+from app.models.project import Project
+from app.schemas.project import (
+    ProjectCreate,
+    ProjectUpdate,
+    ProjectResponse,
+    ProjectListResponse,
+)
 
 router = APIRouter()
 
-# 案件管理APIエンドポイント（後で実装）
+
+@router.post("", response_model=ProjectResponse, status_code=201)
+def create_project(
+    project_data: ProjectCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """案件を新規作成"""
+    # 管理Noの重複チェック
+    existing = db.query(Project).filter(Project.management_no == project_data.management_no).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="この管理Noは既に使用されています")
+
+    # 新規案件作成
+    db_project = Project(
+        **project_data.model_dump(),
+        created_by=current_user.id,
+        actual_hours=0,
+    )
+    db.add(db_project)
+    db.commit()
+    db.refresh(db_project)
+    return db_project
+
+
+@router.get("", response_model=ProjectListResponse)
+def list_projects(
+    page: int = Query(1, ge=1, description="ページ番号"),
+    per_page: int = Query(20, ge=1, le=100, description="1ページあたりの件数"),
+    status: Optional[str] = Query(None, description="ステータスでフィルタ"),
+    machine_no: Optional[str] = Query(None, description="機番で検索"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """案件一覧を取得"""
+    query = db.query(Project)
+
+    # フィルタリング
+    if status:
+        query = query.filter(Project.status == status)
+    if machine_no:
+        query = query.filter(Project.machine_no.contains(machine_no))
+
+    # 総件数取得
+    total = query.count()
+
+    # ページネーション
+    offset = (page - 1) * per_page
+    projects = query.order_by(Project.created_at.desc()).offset(offset).limit(per_page).all()
+
+    return ProjectListResponse(
+        projects=projects,
+        total=total,
+        page=page,
+        per_page=per_page,
+    )
+
+
+@router.get("/{project_id}", response_model=ProjectResponse)
+def get_project(
+    project_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """案件詳細を取得"""
+    project = db.query(Project).filter(Project.id == project_id).first()
+    if not project:
+        raise HTTPException(status_code=404, detail="案件が見つかりません")
+    return project
+
+
+@router.put("/{project_id}", response_model=ProjectResponse)
+def update_project(
+    project_id: UUID,
+    project_data: ProjectUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """案件を更新"""
+    project = db.query(Project).filter(Project.id == project_id).first()
+    if not project:
+        raise HTTPException(status_code=404, detail="案件が見つかりません")
+
+    # 管理Noの重複チェック（変更される場合）
+    if project_data.management_no and project_data.management_no != project.management_no:
+        existing = db.query(Project).filter(Project.management_no == project_data.management_no).first()
+        if existing:
+            raise HTTPException(status_code=400, detail="この管理Noは既に使用されています")
+
+    # 更新
+    update_data = project_data.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(project, key, value)
+
+    db.commit()
+    db.refresh(project)
+    return project
+
+
+@router.delete("/{project_id}", status_code=204)
+def delete_project(
+    project_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """案件を削除"""
+    project = db.query(Project).filter(Project.id == project_id).first()
+    if not project:
+        raise HTTPException(status_code=404, detail="案件が見つかりません")
+
+    db.delete(project)
+    db.commit()
+    return None

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -1,0 +1,60 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import date, datetime
+from uuid import UUID
+
+
+class ProjectBase(BaseModel):
+    management_no: str = Field(..., description="管理No")
+    series: Optional[str] = Field(None, description="シリーズ")
+    generation: Optional[str] = Field(None, description="世代")
+    tonnage: Optional[str] = Field(None, description="トン数")
+    spec_tags: Optional[str] = Field(None, description="仕様タグ")
+    machine_no: Optional[str] = Field(None, description="機番")
+    commission_content: Optional[str] = Field(None, description="業務委託内容")
+    inquiry_type: Optional[str] = Field(None, description="問い合わせ種別")
+    work_category: Optional[str] = Field(None, description="作業区分")
+    estimated_hours: Optional[int] = Field(None, description="予定工数（分単位）")
+    status: str = Field(default="進行中", description="ステータス")
+    start_date: Optional[date] = Field(None, description="開始日")
+    completion_date: Optional[date] = Field(None, description="完了日")
+    drawing_deadline: Optional[date] = Field(None, description="図面締め切り日")
+
+
+class ProjectCreate(ProjectBase):
+    pass
+
+
+class ProjectUpdate(BaseModel):
+    management_no: Optional[str] = None
+    series: Optional[str] = None
+    generation: Optional[str] = None
+    tonnage: Optional[str] = None
+    spec_tags: Optional[str] = None
+    machine_no: Optional[str] = None
+    commission_content: Optional[str] = None
+    inquiry_type: Optional[str] = None
+    work_category: Optional[str] = None
+    estimated_hours: Optional[int] = None
+    status: Optional[str] = None
+    start_date: Optional[date] = None
+    completion_date: Optional[date] = None
+    drawing_deadline: Optional[date] = None
+
+
+class ProjectResponse(ProjectBase):
+    id: UUID
+    actual_hours: int = Field(description="実績工数（分単位）")
+    created_by: Optional[UUID]
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class ProjectListResponse(BaseModel):
+    projects: list[ProjectResponse]
+    total: int
+    page: int
+    per_page: int


### PR DESCRIPTION
## 概要
案件管理機能のバックエンドAPIを実装しました。

## 実装内容
### スキーマ作成 (`backend/app/schemas/project.py`)
- **ProjectBase**: 案件の基本フィールド定義
  - 管理No, シリーズ, 世代, トン数, 仕様タグ
  - 機番, 業務委託内容, 問い合わせ種別, 作業区分
  - 予定工数（分単位）, ステータス
  - 開始日, 完了日, 図面締め切り日
- **ProjectCreate**: 案件新規作成用スキーマ
- **ProjectUpdate**: 案件更新用スキーマ（全フィールドOptional）
- **ProjectResponse**: API応答用スキーマ（id, 実績工数, タイムスタンプ含む）
- **ProjectListResponse**: 一覧取得用スキーマ（ページネーション情報含む）

### APIエンドポイント実装 (`backend/app/api/projects.py`)
- **POST `/api/projects`**: 案件新規作成
  - 管理Noの重複チェック
  - 認証ユーザーをcreated_byに設定
  - 実績工数を0で初期化
- **GET `/api/projects`**: 案件一覧取得
  - ページネーション（page, per_page）
  - ステータスフィルタ（status）
  - 機番検索（machine_no）
  - 作成日降順でソート
- **GET `/api/projects/{project_id}`**: 案件詳細取得
  - UUIDによる案件特定
  - 404エラーハンドリング
- **PUT `/api/projects/{project_id}`**: 案件更新
  - 管理No変更時の重複チェック
  - 部分更新対応（exclude_unset=True）
- **DELETE `/api/projects/{project_id}`**: 案件削除
  - 204 No Contentレスポンス

### 修正内容
- `get_current_user`のインポート元を`app.core.security`から`app.api.auth`に修正

## 動作確認
- Swagger UI（http://localhost:8000/docs）で全エンドポイントの動作を確認済み
- JWT認証が正常に機能することを確認

## 次のステップ
- 工数入力API実装（feat-worklog-api）
- フロントエンド画面実装（feat-dashboard-ui）

🤖 Generated with [Claude Code](https://claude.com/claude-code)