### PR TITLE
feat: 工数入力API実装（CRUD + 集計機能）

### DIFF
--- a/backend/app/api/worklogs.py
+++ b/backend/app/api/worklogs.py
@@ -1,5 +1,210 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+from typing import Optional
+from uuid import UUID
+from datetime import date
+
+from app.core.database import get_db
+from app.api.auth import get_current_user
+from app.models.user import User
+from app.models.worklog import WorkLog
+from app.models.project import Project
+from app.schemas.worklog import (
+    WorkLogCreate,
+    WorkLogUpdate,
+    WorkLogResponse,
+    WorkLogListResponse,
+)
 
 router = APIRouter()
 
-# 工数入力APIエンドポイント（後で実装）
+
+@router.post("", response_model=WorkLogResponse, status_code=201)
+def create_worklog(
+    worklog_data: WorkLogCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """工数入力を新規作成"""
+    # 案件の存在確認
+    project = db.query(Project).filter(Project.id == worklog_data.project_id).first()
+    if not project:
+        raise HTTPException(status_code=404, detail="案件が見つかりません")
+
+    # 新規工数入力作成
+    db_worklog = WorkLog(
+        **worklog_data.model_dump(),
+        user_id=current_user.id,
+    )
+    db.add(db_worklog)
+
+    # 案件の実績工数を更新
+    project.actual_hours += worklog_data.duration_minutes
+
+    db.commit()
+    db.refresh(db_worklog)
+    return db_worklog
+
+
+@router.get("", response_model=WorkLogListResponse)
+def list_worklogs(
+    page: int = Query(1, ge=1, description="ページ番号"),
+    per_page: int = Query(20, ge=1, le=100, description="1ページあたりの件数"),
+    project_id: Optional[UUID] = Query(None, description="案件IDでフィルタ"),
+    work_date: Optional[date] = Query(None, description="作業日でフィルタ"),
+    user_id: Optional[UUID] = Query(None, description="ユーザーIDでフィルタ"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """工数入力一覧を取得"""
+    query = db.query(WorkLog)
+
+    # フィルタリング
+    if project_id:
+        query = query.filter(WorkLog.project_id == project_id)
+    if work_date:
+        query = query.filter(WorkLog.work_date == work_date)
+    if user_id:
+        query = query.filter(WorkLog.user_id == user_id)
+
+    # 総件数取得
+    total = query.count()
+
+    # ページネーション
+    offset = (page - 1) * per_page
+    worklogs = query.order_by(WorkLog.work_date.desc(), WorkLog.created_at.desc()).offset(offset).limit(per_page).all()
+
+    return WorkLogListResponse(
+        worklogs=worklogs,
+        total=total,
+        page=page,
+        per_page=per_page,
+    )
+
+
+@router.get("/{worklog_id}", response_model=WorkLogResponse)
+def get_worklog(
+    worklog_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """工数入力詳細を取得"""
+    worklog = db.query(WorkLog).filter(WorkLog.id == worklog_id).first()
+    if not worklog:
+        raise HTTPException(status_code=404, detail="工数入力が見つかりません")
+    return worklog
+
+
+@router.put("/{worklog_id}", response_model=WorkLogResponse)
+def update_worklog(
+    worklog_id: UUID,
+    worklog_data: WorkLogUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """工数入力を更新"""
+    worklog = db.query(WorkLog).filter(WorkLog.id == worklog_id).first()
+    if not worklog:
+        raise HTTPException(status_code=404, detail="工数入力が見つかりません")
+
+    # 作業時間が変更される場合、案件の実績工数を調整
+    old_duration = worklog.duration_minutes
+    update_data = worklog_data.model_dump(exclude_unset=True)
+    new_duration = update_data.get("duration_minutes", old_duration)
+
+    if new_duration != old_duration:
+        project = db.query(Project).filter(Project.id == worklog.project_id).first()
+        if project:
+            project.actual_hours = project.actual_hours - old_duration + new_duration
+
+    # 更新
+    for key, value in update_data.items():
+        setattr(worklog, key, value)
+
+    db.commit()
+    db.refresh(worklog)
+    return worklog
+
+
+@router.delete("/{worklog_id}", status_code=204)
+def delete_worklog(
+    worklog_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """工数入力を削除"""
+    worklog = db.query(WorkLog).filter(WorkLog.id == worklog_id).first()
+    if not worklog:
+        raise HTTPException(status_code=404, detail="工数入力が見つかりません")
+
+    # 案件の実績工数を減算
+    project = db.query(Project).filter(Project.id == worklog.project_id).first()
+    if project:
+        project.actual_hours -= worklog.duration_minutes
+
+    db.delete(worklog)
+    db.commit()
+    return None
+
+
+@router.get("/summary/{project_id}")
+def get_worklog_summary(
+    project_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """案件の工数集計を取得"""
+    # 案件の存在確認
+    project = db.query(Project).filter(Project.id == project_id).first()
+    if not project:
+        raise HTTPException(status_code=404, detail="案件が見つかりません")
+
+    # ユーザー別工数集計
+    user_summary = (
+        db.query(
+            User.username,
+            func.sum(WorkLog.duration_minutes).label("total_minutes"),
+            func.count(WorkLog.id).label("entry_count"),
+        )
+        .join(WorkLog, WorkLog.user_id == User.id)
+        .filter(WorkLog.project_id == project_id)
+        .group_by(User.id, User.username)
+        .all()
+    )
+
+    # 日別工数集計
+    daily_summary = (
+        db.query(
+            WorkLog.work_date,
+            func.sum(WorkLog.duration_minutes).label("total_minutes"),
+            func.count(WorkLog.id).label("entry_count"),
+        )
+        .filter(WorkLog.project_id == project_id)
+        .group_by(WorkLog.work_date)
+        .order_by(WorkLog.work_date.desc())
+        .all()
+    )
+
+    return {
+        "project_id": project_id,
+        "management_no": project.management_no,
+        "estimated_hours": project.estimated_hours or 0,
+        "actual_hours": project.actual_hours,
+        "by_user": [
+            {
+                "username": row.username,
+                "total_minutes": row.total_minutes,
+                "entry_count": row.entry_count,
+            }
+            for row in user_summary
+        ],
+        "by_date": [
+            {
+                "work_date": row.work_date.isoformat(),
+                "total_minutes": row.total_minutes,
+                "entry_count": row.entry_count,
+            }
+            for row in daily_summary
+        ],
+    }

--- a/backend/app/schemas/worklog.py
+++ b/backend/app/schemas/worklog.py
@@ -1,0 +1,43 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import date, datetime
+from uuid import UUID
+
+
+class WorkLogBase(BaseModel):
+    project_id: UUID = Field(..., description="案件ID")
+    work_date: date = Field(..., description="作業日")
+    start_time: Optional[str] = Field(None, description="開始時刻（HH:MM形式）")
+    end_time: Optional[str] = Field(None, description="終了時刻（HH:MM形式）")
+    duration_minutes: int = Field(..., gt=0, description="作業時間（分単位）")
+    work_content: Optional[str] = Field(None, description="作業内容")
+
+
+class WorkLogCreate(WorkLogBase):
+    pass
+
+
+class WorkLogUpdate(BaseModel):
+    project_id: Optional[UUID] = None
+    work_date: Optional[date] = None
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    duration_minutes: Optional[int] = Field(None, gt=0)
+    work_content: Optional[str] = None
+
+
+class WorkLogResponse(WorkLogBase):
+    id: UUID
+    user_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class WorkLogListResponse(BaseModel):
+    worklogs: list[WorkLogResponse]
+    total: int
+    page: int
+    per_page: int


### PR DESCRIPTION
## 概要
工数入力機能のバックエンドAPIを実装しました。案件に対する作業時間の記録と集計が可能です。

## 実装内容
### スキーマ作成 (`backend/app/schemas/worklog.py`)
- **WorkLogBase**: 工数入力の基本フィールド定義
  - project_id（案件ID）
  - work_date（作業日）
  - start_time / end_time（開始・終了時刻、HH:MM形式）
  - duration_minutes（作業時間、分単位）
  - work_content（作業内容）
- **WorkLogCreate**: 工数入力新規作成用スキーマ
- **WorkLogUpdate**: 工数入力更新用スキーマ（全フィールドOptional）
- **WorkLogResponse**: API応答用スキーマ（id, user_id, タイムスタンプ含む）
- **WorkLogListResponse**: 一覧取得用スキーマ（ページネーション情報含む）

### APIエンドポイント実装 (`backend/app/api/worklogs.py`)
- **POST `/api/worklogs`**: 工数入力新規作成
  - 案件の存在確認
  - 認証ユーザーをuser_idに設定
  - **案件の実績工数（actual_hours）を自動更新**
  
- **GET `/api/worklogs`**: 工数入力一覧取得
  - ページネーション（page, per_page）
  - 案件IDフィルタ（project_id）
  - 作業日フィルタ（work_date）
  - ユーザーIDフィルタ（user_id）
  - 作業日・作成日降順でソート
  
- **GET `/api/worklogs/{worklog_id}`**: 工数入力詳細取得
  - UUIDによる工数入力特定
  - 404エラーハンドリング
  
- **PUT `/api/worklogs/{worklog_id}`**: 工数入力更新
  - 作業時間変更時、**案件の実績工数を自動調整**（旧時間を減算、新時間を加算）
  - 部分更新対応（exclude_unset=True）
  
- **DELETE `/api/worklogs/{worklog_id}`**: 工数入力削除
  - **案件の実績工数から作業時間を自動減算**
  - 204 No Contentレスポンス
  
- **GET `/api/worklogs/summary/{project_id}`**: 案件の工数集計取得（新機能）
  - 案件の予定工数・実績工数
  - ユーザー別集計（合計時間、入力回数）
  - 日別集計（合計時間、入力回数）
  - SQLAlchemy の集計関数（func.sum, func.count）を活用

## 動作確認
- Swagger UI（http://localhost:8000/docs）で全エンドポイントの動作を確認済み
- JWT認証が正常に機能することを確認
- 工数入力と案件の実績工数の連動を確認

## 次のステップ
- フロントエンド画面実装（feat-dashboard-ui）
  - ダッシュボード画面
  - 案件一覧画面
  - 工数入力画面（グリッドUI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)